### PR TITLE
weird experiment on intent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "respo"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "cirru_parser",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "respo"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "cirru_parser",
  "js-sys",

--- a/demo_respo/src/main.rs
+++ b/demo_respo/src/main.rs
@@ -34,7 +34,6 @@ struct App {
 
 impl RespoApp for App {
   type Model = Store;
-  type Action = ActionOp;
 
   fn get_store(&self) -> &Rc<RefCell<Self::Model>> {
     &self.store
@@ -47,7 +46,7 @@ impl RespoApp for App {
     APP_STORE_KEY
   }
 
-  fn dispatch(store_to_action: Rc<RefCell<Self::Model>>, op: Self::Action) -> Result<(), String> {
+  fn dispatch(store_to_action: Rc<RefCell<Self::Model>>, op: <Self::Model as RespoStore>::Action) -> Result<(), String> {
     if let Some(intent) = op.detect_intent() {
       intent.update(store_to_action)
     } else {
@@ -56,7 +55,7 @@ impl RespoApp for App {
     }
   }
 
-  fn view(store: Ref<Self::Model>) -> Result<RespoNode<Self::Action>, String> {
+  fn view(store: Ref<Self::Model>) -> Result<RespoNode<<Self::Model as RespoStore>::Action>, String> {
     let states = &store.states;
     // util::log!("global store: {:?}", store);
 

--- a/demo_respo/src/main.rs
+++ b/demo_respo/src/main.rs
@@ -7,10 +7,11 @@ mod store;
 mod task;
 mod todolist;
 
-use std::cell::{Ref, RefCell, RefMut};
+use std::cell::{Ref, RefCell};
 use std::panic;
 use std::rc::Rc;
 
+use respo::RespoAction;
 use web_sys::Node;
 
 use respo::ui::ui_global;
@@ -46,8 +47,13 @@ impl RespoApp for App {
     APP_STORE_KEY
   }
 
-  fn dispatch(store: &mut RefMut<Self::Model>, op: Self::Action) -> Result<(), String> {
-    store.update(op)
+  fn dispatch(store_to_action: Rc<RefCell<Self::Model>>, op: Self::Action) -> Result<(), String> {
+    if let Some(intent) = op.detect_intent() {
+      intent.update(store_to_action)
+    } else {
+      let mut store = store_to_action.borrow_mut();
+      store.update(op)
+    }
   }
 
   fn view(store: Ref<Self::Model>) -> Result<RespoNode<Self::Action>, String> {

--- a/respo/Cargo.toml
+++ b/respo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "respo"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "a tiny virtual DOM library migrated from ClojureScript"
 license = "Apache-2.0"

--- a/respo/Cargo.toml
+++ b/respo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "respo"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "a tiny virtual DOM library migrated from ClojureScript"
 license = "Apache-2.0"

--- a/respo/src/app.rs
+++ b/respo/src/app.rs
@@ -3,7 +3,7 @@ pub(crate) mod patch;
 pub(crate) mod renderer;
 
 use std::{
-  cell::{Ref, RefCell, RefMut},
+  cell::{Ref, RefCell},
   fmt::Debug,
   rc::Rc,
 };
@@ -30,7 +30,7 @@ pub trait RespoApp {
   type Action: Debug + Clone + RespoAction + 'static;
 
   /// simulating pure function updates to the model, but actually it's mutations
-  fn dispatch(store: &mut RefMut<Self::Model>, action: Self::Action) -> Result<(), String>;
+  fn dispatch(store: Rc<RefCell<Self::Model>>, action: Self::Action) -> Result<(), String>;
 
   /// used when saving to local storage
   fn pick_storage_key() -> &'static str {
@@ -60,9 +60,8 @@ pub trait RespoApp {
       let store_to_action = global_store.to_owned();
       move |op: Self::Action| -> Result<(), String> {
         // util::log!("action {:?} store, {:?}", op, store_to_action.borrow());
-        let mut store = store_to_action.borrow_mut();
 
-        Self::dispatch(&mut store, op)?;
+        Self::dispatch(store_to_action.to_owned(), op)?;
         // util::log!("store after action {:?}", store);
         Ok(())
       }

--- a/respo/src/node.rs
+++ b/respo/src/node.rs
@@ -190,15 +190,21 @@ pub trait RespoAction {
     })
   }
 
+  /// builder for intent actions
   fn build_intent_action(op: Self::Intent) -> Self
   where
-    Self: Sized;
+    Self: Sized,
+  {
+    todo!("build_intent_action need to be implemented when intent({:?}) is used ", op)
+  }
 
   /// a builder for states change
   fn states_action(a: RespoUpdateState) -> Self;
 
   /// handle intent seperately since it might contain effects
-  fn detect_intent(&self) -> Option<Self::Intent>;
+  fn detect_intent(&self) -> Option<Self::Intent> {
+    None
+  }
 }
 
 impl<T> DispatchFn<T>

--- a/respo/src/node.rs
+++ b/respo/src/node.rs
@@ -172,6 +172,7 @@ where
 /// guide for actions to be dispatched
 /// expecially for how you update states
 pub trait RespoAction {
+  type Intent: Debug + Clone + PartialEq + Eq;
   /// to provide syntax sugar to dispatch.run_state
   fn build_states_action(cursor: &[Rc<str>], a: Option<RespoStateBranch>) -> Self
   where
@@ -189,8 +190,15 @@ pub trait RespoAction {
     })
   }
 
+  fn build_intent_action(op: Self::Intent) -> Self
+  where
+    Self: Sized;
+
   /// a builder for states change
   fn states_action(a: RespoUpdateState) -> Self;
+
+  /// handle intent seperately since it might contain effects
+  fn detect_intent(&self) -> Option<Self::Intent>;
 }
 
 impl<T> DispatchFn<T>
@@ -208,6 +216,10 @@ where
   {
     let a = Rc::new(data);
     (self.0)(T::build_states_action(cursor, Some(RespoStateBranch::new(a))))
+  }
+  /// alias for dispatching intent
+  pub fn run_intent(&self, op: T::Intent) -> Result<(), String> {
+    (self.0)(T::build_intent_action(op))
   }
   /// reset state to empty
   pub fn run_empty_state(&self, cursor: &[Rc<str>]) -> Result<(), String> {

--- a/respo/src/node/element/alias.rs
+++ b/respo/src/node/element/alias.rs
@@ -28,6 +28,7 @@ declare_tag!(div, "`<div/>`");
 declare_tag!(header, "`<header/>`");
 declare_tag!(section, "`<section/>`");
 declare_tag!(footer, "`<footer/>`");
+declare_tag!(br, "`<br/>`");
 declare_tag!(span, "`<span/>`");
 declare_tag!(input, "`<input/>`");
 declare_tag!(textarea, "`<input/>`");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a button for "demo inc twice," allowing users to increment the counter by two with a single click.
  - Display both local and global state values in the counter component.

- **Bug Fixes**
  - Improved the dispatch function to handle intent detection before updating the store.

- **Enhancements**
  - Improved state management with the introduction of `IntentOp` for handling complex actions.
  - Updated internal logic to support more advanced action detection and execution.

- **Version Update**
  - Incremented package version from `0.1.6` to `0.1.8`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->