### PR TITLE
explore casted state tree for better typed component states

### DIFF
--- a/demo_respo/src/counter.rs
+++ b/demo_respo/src/counter.rs
@@ -4,27 +4,28 @@ use respo::{
   br, button,
   css::{CssColor, RespoStyle},
   div, span,
+  states_tree::RespoStatesTreeCasted,
   ui::ui_button,
   util, DispatchFn, RespoElement, RespoEvent,
 };
 use respo_state_derive::RespoState;
 use serde::{Deserialize, Serialize};
 
-use respo::states_tree::{RespoState, RespoStatesTree};
+use respo::states_tree::RespoState;
 
 use crate::IntentOp;
 
 use super::store::ActionOp;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, RespoState)]
-struct MainState {
+pub(crate) struct CounterState {
   counted: i32,
 }
 
-pub fn comp_counter(states: &RespoStatesTree, global_counted: i32) -> Result<RespoElement<ActionOp>, String> {
+pub fn comp_counter(states: RespoStatesTreeCasted<CounterState>, global_counted: i32) -> Result<RespoElement<ActionOp>, String> {
   let cursor = states.path();
 
-  let state = states.cast_branch::<MainState>()?;
+  let state = states.data;
   let counted = state.counted;
 
   let on_inc = {
@@ -39,7 +40,7 @@ pub fn comp_counter(states: &RespoStatesTree, global_counted: i32) -> Result<Res
       dispatch.run(ActionOp::Increment)?;
       dispatch.run_state(
         &cursor,
-        MainState {
+        CounterState {
           counted: state.counted + 2,
         },
       )?;
@@ -55,7 +56,7 @@ pub fn comp_counter(states: &RespoStatesTree, global_counted: i32) -> Result<Res
       dispatch.run(ActionOp::Decrement)?;
       dispatch.run_state(
         &cursor,
-        MainState {
+        CounterState {
           counted: state.counted - 1,
         },
       )?;
@@ -71,7 +72,7 @@ pub fn comp_counter(states: &RespoStatesTree, global_counted: i32) -> Result<Res
       dispatch.run(ActionOp::Intent(IntentOp::IncTwice))?;
       dispatch.run_state(
         &cursor,
-        MainState {
+        CounterState {
           counted: state.counted + 2,
         },
       )?;

--- a/demo_respo/src/main.rs
+++ b/demo_respo/src/main.rs
@@ -11,6 +11,7 @@ use std::cell::{Ref, RefCell};
 use std::panic;
 use std::rc::Rc;
 
+use counter::CounterState;
 use respo::RespoAction;
 use web_sys::Node;
 
@@ -64,7 +65,7 @@ impl RespoApp for App {
         .class(ui_global())
         .style(RespoStyle::default().padding(12.0))
         .children([
-          comp_counter(&states.pick("counter"), store.counted)?.to_node(),
+          comp_counter(states.pick("counter").data_cast_to::<CounterState>()?, store.counted)?.to_node(),
           comp_panel(&states.pick("panel"))?,
           comp_todolist(&states.pick("todolist"), &store.tasks)?.to_node(),
           comp_plugins_demo(&states.pick("plugins-demo"))?.to_node(),

--- a/demo_respo/src/main.rs
+++ b/demo_respo/src/main.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 
 use counter::CounterState;
 use respo::RespoAction;
+use todolist::TodolistState;
 use web_sys::Node;
 
 use respo::ui::ui_global;
@@ -23,7 +24,7 @@ use self::counter::comp_counter;
 pub use self::store::ActionOp;
 use self::store::*;
 use self::todolist::comp_todolist;
-use panel::comp_panel;
+use panel::{comp_panel, PanelState};
 use plugins::comp_plugins_demo;
 
 const APP_STORE_KEY: &str = "demo_respo_store";
@@ -65,10 +66,10 @@ impl RespoApp for App {
         .class(ui_global())
         .style(RespoStyle::default().padding(12.0))
         .children([
-          comp_counter(states.pick("counter").data_cast_to::<CounterState>()?, store.counted)?.to_node(),
-          comp_panel(&states.pick("panel"))?,
-          comp_todolist(&states.pick("todolist"), &store.tasks)?.to_node(),
-          comp_plugins_demo(&states.pick("plugins-demo"))?.to_node(),
+          comp_counter(states.pick_to::<CounterState>("counter")?, store.counted)?.to_node(),
+          comp_panel(states.pick_to::<PanelState>("panel")?)?,
+          comp_todolist(states.pick_to::<TodolistState>("todolist")?, &store.tasks)?.to_node(),
+          comp_plugins_demo(states.pick_to::<()>("plugins-demo")?)?.to_node(),
         ])
         .to_node(),
     )

--- a/demo_respo/src/panel.rs
+++ b/demo_respo/src/panel.rs
@@ -8,14 +8,15 @@ use crate::store::ActionOp;
 
 use respo::{
   button, div, input, space, span,
+  states_tree::RespoStatesTreeCasted,
   ui::{ui_button, ui_input},
   util, DispatchFn, RespoComponent, RespoEffect, RespoEvent, RespoNode,
 };
 
-use respo::states_tree::{RespoState, RespoStatesTree};
+use respo::states_tree::RespoState;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, RespoState)]
-struct PanelState {
+pub(crate) struct PanelState {
   content: String,
 }
 
@@ -34,9 +35,9 @@ impl RespoEffect for PanelMount {
   }
 }
 
-pub fn comp_panel(states: &RespoStatesTree) -> Result<RespoNode<ActionOp>, String> {
+pub fn comp_panel(states: RespoStatesTreeCasted<PanelState>) -> Result<RespoNode<ActionOp>, String> {
   let cursor = states.path();
-  let state = states.cast_branch::<PanelState>()?;
+  let state = states.data;
 
   let on_input = {
     let cursor = cursor.to_owned();

--- a/demo_respo/src/plugins.rs
+++ b/demo_respo/src/plugins.rs
@@ -4,21 +4,22 @@ use respo::{RespoElement, RespoEvent};
 
 use respo::{button, div, span, ui::ui_button, util, DispatchFn};
 
-use respo::states_tree::RespoStatesTree;
+use respo::states_tree::RespoStatesTreeCasted;
 
 use respo::ui::dialog::{
-  AlertOptions, AlertPlugin, AlertPluginInterface, ConfirmOptions, ConfirmPlugin, ConfirmPluginInterface, DrawerOptions, DrawerPlugin,
-  DrawerPluginInterface, DrawerRenderer, ModalOptions, ModalPlugin, ModalPluginInterface, ModalRenderer, PromptOptions, PromptPlugin,
-  PromptPluginInterface, PromptValidator,
+  AlertOptions, AlertPlugin, AlertPluginInterface, AlertPluginState, ConfirmOptions, ConfirmPlugin, ConfirmPluginInterface,
+  ConfirmPluginState, DrawerOptions, DrawerPlugin, DrawerPluginInterface, DrawerPluginState, DrawerRenderer, ModalOptions, ModalPlugin,
+  ModalPluginInterface, ModalPluginState, ModalRenderer, PromptOptions, PromptPlugin, PromptPluginInterface, PromptPluginState,
+  PromptValidator,
 };
 
 use super::store::*;
 
-pub fn comp_plugins_demo(states: &RespoStatesTree) -> Result<RespoElement<ActionOp>, String> {
+pub fn comp_plugins_demo(states: RespoStatesTreeCasted<()>) -> Result<RespoElement<ActionOp>, String> {
   // respo::util::log!("re-render");
 
   let alert_plugin = AlertPlugin::new(
-    states.pick("info"),
+    states.pick_to::<AlertPluginState>("info")?,
     AlertOptions {
       // card_style: RespoStyle::default().background_color(CssColor::Blue),
       ..AlertOptions::default()
@@ -43,7 +44,7 @@ pub fn comp_plugins_demo(states: &RespoStatesTree) -> Result<RespoElement<Action
   };
 
   let confirm_plugin = ConfirmPlugin::new(
-    states.pick("confirm"),
+    states.pick_to::<ConfirmPluginState>("confirm")?,
     ConfirmOptions::default(),
     |_dispatch: DispatchFn<ActionOp>| {
       respo::util::log!("on confirm");
@@ -67,7 +68,7 @@ pub fn comp_plugins_demo(states: &RespoStatesTree) -> Result<RespoElement<Action
   };
 
   let prompt_plugin = PromptPlugin::new(
-    states.pick("prompt"),
+    states.pick_to::<PromptPluginState>("prompt")?,
     PromptOptions {
       text: Some(String::from("Demo text(length 3~8)")),
       validator: Some(PromptValidator::new(|text| {
@@ -106,7 +107,7 @@ pub fn comp_plugins_demo(states: &RespoStatesTree) -> Result<RespoElement<Action
   // declare modal
 
   let modal_plugin = ModalPlugin::new(
-    states.pick("modal"),
+    states.pick_to::<ModalPluginState>("modal")?,
     ModalOptions {
       title: Some(String::from("Modal demo")),
       render: ModalRenderer::new(|close_modal: _| {
@@ -145,7 +146,7 @@ pub fn comp_plugins_demo(states: &RespoStatesTree) -> Result<RespoElement<Action
   // declare drawer
 
   let drawer_plugin = DrawerPlugin::new(
-    states.pick("drawer"),
+    states.pick_to::<DrawerPluginState>("drawer")?,
     DrawerOptions {
       title: Some(String::from("Modal demo")),
       render: DrawerRenderer::new(|close_drawer: _| {

--- a/demo_respo/src/task.rs
+++ b/demo_respo/src/task.rs
@@ -6,17 +6,19 @@ use memoize::memoize;
 use respo::{
   button,
   css::{CssColor, CssSize, RespoStyle},
-  div, input, space, span, static_styles,
+  div, input, space, span,
+  states_tree::RespoStatesTreeCasted,
+  static_styles,
   ui::{ui_button, ui_center, ui_input, ui_row_middle},
   util, DispatchFn, RespoComponent, RespoEffect, RespoEvent, RespoNode,
 };
 
-use respo::states_tree::{RespoState, RespoStatesTree};
+use respo::states_tree::RespoState;
 
 use super::store::*;
 
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq, Serialize, Deserialize, RespoState)]
-struct TaskState {
+pub(crate) struct TaskState {
   draft: String,
 }
 
@@ -35,7 +37,7 @@ impl RespoEffect for TaskUpdateEffect {
 #[memoize(Capacity: 40)]
 pub fn comp_task(
   // _memo_caches: MemoCache<RespoNode<ActionOp>>,
-  states: RespoStatesTree,
+  states: RespoStatesTreeCasted<TaskState>,
   task: Task,
 ) -> Result<RespoNode<ActionOp>, String> {
   respo::util::log!("calling task function");
@@ -43,7 +45,7 @@ pub fn comp_task(
   let task_id = &task.id;
 
   let cursor = states.path();
-  let state = states.cast_branch::<TaskState>()?;
+  let state = states.data;
 
   let on_toggle = {
     let tid = task_id.to_owned();

--- a/respo/src/states_tree.rs
+++ b/respo/src/states_tree.rs
@@ -2,6 +2,7 @@
 //! `RespoStatesTree` tree has concept of "cursor", which is a path to the current state in the tree.
 //! use `branch.pick(name)` to get a child branch, and `branch.set_in_mut(change)` to update the tree.
 
+mod casted;
 mod dyn_eq;
 mod state;
 
@@ -11,6 +12,8 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::rc::Rc;
+
+pub use casted::RespoStatesTreeCasted;
 
 use crate::log;
 pub(crate) use dyn_eq::DynEq;
@@ -136,6 +139,20 @@ impl RespoStatesTree {
         self.branches.insert(p0.to_owned(), Box::new(branch));
       }
     }
+  }
+
+  /// cast tree with a new type in data
+  pub fn data_cast_to<T>(&self) -> Result<RespoStatesTreeCasted<T>, String>
+  where
+    T: Clone + Default + RespoState + 'static,
+  {
+    let b = self.cast_branch::<T>()?;
+    Ok(RespoStatesTreeCasted {
+      data: b,
+      backup: self.backup.to_owned(),
+      cursor: self.cursor.to_owned(),
+      branches: self.branches.to_owned(),
+    })
   }
 }
 

--- a/respo/src/states_tree/casted.rs
+++ b/respo/src/states_tree/casted.rs
@@ -1,9 +1,10 @@
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::rc::Rc;
 
-use super::RespoStatesTree;
+use super::{RespoState, RespoStatesTree};
 
 /// similar to RespoStatesTree but with a generic data type
 #[derive(Debug, Clone, Default)]
@@ -20,9 +21,67 @@ pub struct RespoStatesTreeCasted<T> {
   pub branches: BTreeMap<Rc<str>, Box<RespoStatesTree>>,
 }
 
-impl<T> RespoStatesTreeCasted<T> {
+impl<T> Hash for RespoStatesTreeCasted<T>
+where
+  T: Hash,
+{
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.cursor.hash(state);
+    self.data.hash(state);
+    // backup is not real data
+    self.branches.hash(state);
+  }
+}
+
+impl<T> PartialEq for RespoStatesTreeCasted<T>
+where
+  T: PartialEq,
+{
+  fn eq(&self, other: &Self) -> bool {
+    // backup is only for backup
+    // this trick might cause inconsistency in some cases after reloaded
+    self.cursor == other.cursor && self.data == other.data && self.branches == other.branches
+  }
+}
+impl<T> Eq for RespoStatesTreeCasted<T> where T: PartialEq {}
+
+impl<T> RespoStatesTreeCasted<T>
+where
+  T: Default,
+{
   /// get cursor
   pub fn path(&self) -> Vec<Rc<str>> {
     self.cursor.to_owned()
+  }
+
+  /// pick a child branch as new cursor
+  pub fn pick_to<U>(&self, name: &str) -> Result<RespoStatesTreeCasted<U>, String>
+  where
+    U: Clone + Default + RespoState + 'static,
+  {
+    let mut next_cursor = self.cursor.to_owned();
+    next_cursor.push(Rc::from(name));
+
+    if self.branches.contains_key(name) {
+      let prev = &self.branches[name];
+      let branch = prev.cast_branch::<U>()?;
+      Ok(RespoStatesTreeCasted {
+        data: branch.to_owned(),
+        backup: prev.backup.to_owned(),
+        // data_revision: prev.data_revision,
+        // data_type_name: prev.data_type_name.to_owned(),
+        cursor: next_cursor,
+        branches: prev.branches.to_owned(),
+      })
+    } else {
+      Ok(RespoStatesTreeCasted {
+        data: Rc::new(U::default()),
+        backup: None,
+        cursor: next_cursor,
+        // data_type_name: None,
+        // data_revision: 0,
+        branches: BTreeMap::new(),
+      })
+    }
   }
 }

--- a/respo/src/states_tree/casted.rs
+++ b/respo/src/states_tree/casted.rs
@@ -1,0 +1,28 @@
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::rc::Rc;
+
+use super::RespoStatesTree;
+
+/// similar to RespoStatesTree but with a generic data type
+#[derive(Debug, Clone, Default)]
+pub struct RespoStatesTreeCasted<T> {
+  // #[serde(skip)]
+  /// local data
+  pub data: Rc<T>,
+  pub backup: Option<Value>,
+  /// the path to the current state in the tree, use in updating
+  pub cursor: Vec<Rc<str>>,
+  // pub data_type_name: Option<TypeId>,
+  // pub data_revision: usize,
+  /// holding children states
+  pub branches: BTreeMap<Rc<str>, Box<RespoStatesTree>>,
+}
+
+impl<T> RespoStatesTreeCasted<T> {
+  /// get cursor
+  pub fn path(&self) -> Vec<Rc<str>> {
+    self.cursor.to_owned()
+  }
+}

--- a/respo/src/ui/dialog.rs
+++ b/respo/src/ui/dialog.rs
@@ -20,11 +20,11 @@ use crate::{app, input, static_styles, util, RespoComponent};
 
 pub(crate) const BUTTON_NAME: &str = "dialog-button";
 
-pub use alert::{AlertOptions, AlertPlugin, AlertPluginInterface};
-pub use confirm::{ConfirmOptions, ConfirmPlugin, ConfirmPluginInterface};
-pub use drawer::{DrawerOptions, DrawerPlugin, DrawerPluginInterface, DrawerRenderer};
-pub use modal::{ModalOptions, ModalPlugin, ModalPluginInterface, ModalRenderer};
-pub use prompt::{PromptOptions, PromptPlugin, PromptPluginInterface, PromptValidator};
+pub use alert::{AlertOptions, AlertPlugin, AlertPluginInterface, AlertPluginState};
+pub use confirm::{ConfirmOptions, ConfirmPlugin, ConfirmPluginInterface, ConfirmPluginState};
+pub use drawer::{DrawerOptions, DrawerPlugin, DrawerPluginInterface, DrawerPluginState, DrawerRenderer};
+pub use modal::{ModalOptions, ModalPlugin, ModalPluginInterface, ModalPluginState, ModalRenderer};
+pub use prompt::{PromptOptions, PromptPlugin, PromptPluginInterface, PromptPluginState, PromptValidator};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EffectFocus {

--- a/respo/src/ui/dialog/alert.rs
+++ b/respo/src/ui/dialog/alert.rs
@@ -14,7 +14,7 @@ use crate::node::css::{CssLineHeight, CssPosition, RespoStyle};
 use crate::node::{DispatchFn, RespoAction, RespoEvent, RespoNode};
 use crate::{button, div, space, span, RespoComponent};
 
-use crate::states_tree::{RespoState, RespoStatesTree};
+use crate::states_tree::{RespoState, RespoStatesTreeCasted};
 
 use super::comp_esc_listener;
 
@@ -121,7 +121,7 @@ where
   fn close(&self, dispatch: DispatchFn<T>) -> Result<(), String>;
 
   /// show alert with options, `on_read` is the callback function when read button is clicked
-  fn new(states: RespoStatesTree, options: AlertOptions, on_read: U) -> Result<Self, String>
+  fn new(states: RespoStatesTreeCasted<AlertPluginState>, options: AlertOptions, on_read: U) -> Result<Self, String>
   where
     Self: std::marker::Sized;
 
@@ -130,7 +130,7 @@ where
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, RespoState)]
-struct AlertPluginState {
+pub struct AlertPluginState {
   show: bool,
   text: Option<String>,
 }
@@ -212,9 +212,9 @@ where
     Ok(())
   }
 
-  fn new(states: RespoStatesTree, options: AlertOptions, on_read: U) -> Result<Self, String> {
+  fn new(states: RespoStatesTreeCasted<AlertPluginState>, options: AlertOptions, on_read: U) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<AlertPluginState>()?;
+    let state = states.data;
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/confirm.rs
+++ b/respo/src/ui/dialog/confirm.rs
@@ -16,7 +16,7 @@ use crate::node::css::{CssLineHeight, CssPosition, RespoStyle};
 use crate::node::{DispatchFn, RespoAction, RespoEvent, RespoNode};
 use crate::{app, button, div, space, span, RespoComponent};
 
-use crate::states_tree::{RespoState, RespoStatesTree};
+use crate::states_tree::{RespoState, RespoStatesTreeCasted};
 
 use crate::ui::dialog::{EffectFocus, EffectModalFade, BUTTON_NAME};
 
@@ -130,7 +130,7 @@ where
   fn close(&self, dispatch: DispatchFn<T>) -> Result<(), String>;
 
   /// creates a new instance of confirm plugin, second parameter is a callback when confirmed
-  fn new(states: RespoStatesTree, options: ConfirmOptions, on_confirm: U) -> Result<Self, String>
+  fn new(states: RespoStatesTreeCasted<ConfirmPluginState>, options: ConfirmOptions, on_confirm: U) -> Result<Self, String>
   where
     Self: std::marker::Sized;
 
@@ -138,7 +138,7 @@ where
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, RespoState)]
-struct ConfirmPluginState {
+pub struct ConfirmPluginState {
   show: bool,
   text: Option<String>,
 }
@@ -245,9 +245,9 @@ where
     Ok(())
   }
 
-  fn new(states: RespoStatesTree, options: ConfirmOptions, on_confirm: U) -> Result<Self, String> {
+  fn new(states: RespoStatesTreeCasted<ConfirmPluginState>, options: ConfirmOptions, on_confirm: U) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<ConfirmPluginState>()?;
+    let state = states.data;
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/drawer.rs
+++ b/respo/src/ui/dialog/drawer.rs
@@ -13,7 +13,7 @@ use crate::node::css::{CssLineHeight, CssPosition, RespoStyle};
 use crate::node::{DispatchFn, RespoAction, RespoEvent, RespoNode};
 use crate::{div, space, span, RespoComponent};
 
-use crate::states_tree::{RespoState, RespoStatesTree};
+use crate::states_tree::{RespoState, RespoStatesTreeCasted};
 
 use crate::ui::dialog::EffectDrawerFade;
 
@@ -162,7 +162,7 @@ where
   /// to close drawer
   fn close(&self, dispatch: DispatchFn<T>) -> Result<(), String>;
 
-  fn new(states: RespoStatesTree, options: DrawerOptions<T>) -> Result<Self, String>
+  fn new(states: RespoStatesTreeCasted<DrawerPluginState>, options: DrawerOptions<T>) -> Result<Self, String>
   where
     Self: std::marker::Sized;
 
@@ -171,7 +171,7 @@ where
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, RespoState)]
-struct DrawerPluginState {
+pub struct DrawerPluginState {
   show: bool,
 }
 
@@ -212,9 +212,9 @@ where
     Ok(())
   }
 
-  fn new(states: RespoStatesTree, options: DrawerOptions<T>) -> Result<Self, String> {
+  fn new(states: RespoStatesTreeCasted<DrawerPluginState>, options: DrawerOptions<T>) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<DrawerPluginState>()?;
+    let state = states.data;
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/modal.rs
+++ b/respo/src/ui/dialog/modal.rs
@@ -13,7 +13,7 @@ use crate::node::css::{CssLineHeight, CssPosition, RespoStyle};
 use crate::node::{DispatchFn, RespoAction, RespoEvent, RespoNode};
 use crate::{div, space, span, RespoComponent};
 
-use crate::states_tree::{RespoState, RespoStatesTree};
+use crate::states_tree::{RespoState, RespoStatesTreeCasted};
 
 use crate::ui::dialog::EffectModalFade;
 
@@ -164,7 +164,7 @@ where
   /// to close modal
   fn close(&self, dispatch: DispatchFn<T>) -> Result<(), String>;
 
-  fn new(states: RespoStatesTree, options: ModalOptions<T>) -> Result<Self, String>
+  fn new(states: RespoStatesTreeCasted<ModalPluginState>, options: ModalOptions<T>) -> Result<Self, String>
   where
     Self: std::marker::Sized;
 
@@ -173,7 +173,7 @@ where
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, RespoState)]
-struct ModalPluginState {
+pub struct ModalPluginState {
   show: bool,
 }
 
@@ -214,9 +214,9 @@ where
     Ok(())
   }
 
-  fn new(states: RespoStatesTree, options: ModalOptions<T>) -> Result<Self, String> {
+  fn new(states: RespoStatesTreeCasted<ModalPluginState>, options: ModalOptions<T>) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<ModalPluginState>()?;
+    let state = states.data;
 
     let instance = Self {
       state,


### PR DESCRIPTION
the issue is current component takes `RespoStatesTree` and then downcast its `.data` field to a component state struct. which means type checking for component is lost. Although it's lost in the design of Respo, I'm trying to provide more type info to component function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced specific state types for different components, improving clarity and type safety.
  - Added new state types for plugins: Alert, Confirm, Drawer, Modal, and Prompt.

- **Improvements**
  - Updated function signatures to use type-casted state trees for improved state management.
  - Enhanced component initialization and state handling with new state types.

- **Refactor**
  - Renamed and restructured plugin interfaces and states for better organization and readability.

- **Documentation**
  - Updated visibility and documentation for new state types and function signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->