### PR TITLE
simplify cast_branch by removing result container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "respo"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "cirru_parser",
  "js-sys",

--- a/demo_respo/src/counter.rs
+++ b/demo_respo/src/counter.rs
@@ -24,7 +24,7 @@ struct MainState {
 pub fn comp_counter(states: &RespoStatesTree, global_counted: i32) -> Result<RespoElement<ActionOp>, String> {
   let cursor = states.path();
 
-  let state = states.cast_branch::<MainState>()?;
+  let state = states.cast_branch::<MainState>();
   let counted = state.counted;
 
   let on_inc = {

--- a/demo_respo/src/panel.rs
+++ b/demo_respo/src/panel.rs
@@ -36,7 +36,7 @@ impl RespoEffect for PanelMount {
 
 pub fn comp_panel(states: &RespoStatesTree) -> Result<RespoNode<ActionOp>, String> {
   let cursor = states.path();
-  let state = states.cast_branch::<PanelState>()?;
+  let state = states.cast_branch::<PanelState>();
 
   let on_input = {
     let cursor = cursor.to_owned();

--- a/demo_respo/src/task.rs
+++ b/demo_respo/src/task.rs
@@ -43,7 +43,7 @@ pub fn comp_task(
   let task_id = &task.id;
 
   let cursor = states.path();
-  let state = states.cast_branch::<TaskState>()?;
+  let state = states.cast_branch::<TaskState>();
 
   let on_toggle = {
     let tid = task_id.to_owned();

--- a/demo_respo/src/todolist.rs
+++ b/demo_respo/src/todolist.rs
@@ -16,7 +16,7 @@ struct TodolistState {
 
 pub fn comp_todolist(states: &RespoStatesTree, tasks: &[Task]) -> Result<RespoElement<ActionOp>, String> {
   let cursor = states.path();
-  let state = states.cast_branch::<TodolistState>()?;
+  let state = states.cast_branch::<TodolistState>();
 
   let mut children: Vec<(RespoIndexKey, RespoNode<_>)> = vec![];
   for task in tasks {

--- a/respo/Cargo.toml
+++ b/respo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "respo"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "a tiny virtual DOM library migrated from ClojureScript"
 license = "Apache-2.0"

--- a/respo/src/ui/dialog/alert.rs
+++ b/respo/src/ui/dialog/alert.rs
@@ -214,7 +214,7 @@ where
 
   fn new(states: RespoStatesTree, options: AlertOptions, on_read: U) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<AlertPluginState>()?;
+    let state = states.cast_branch::<AlertPluginState>();
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/confirm.rs
+++ b/respo/src/ui/dialog/confirm.rs
@@ -247,7 +247,7 @@ where
 
   fn new(states: RespoStatesTree, options: ConfirmOptions, on_confirm: U) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<ConfirmPluginState>()?;
+    let state = states.cast_branch::<ConfirmPluginState>();
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/drawer.rs
+++ b/respo/src/ui/dialog/drawer.rs
@@ -214,7 +214,7 @@ where
 
   fn new(states: RespoStatesTree, options: DrawerOptions<T>) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<DrawerPluginState>()?;
+    let state = states.cast_branch::<DrawerPluginState>();
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/modal.rs
+++ b/respo/src/ui/dialog/modal.rs
@@ -216,7 +216,7 @@ where
 
   fn new(states: RespoStatesTree, options: ModalOptions<T>) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<ModalPluginState>()?;
+    let state = states.cast_branch::<ModalPluginState>();
 
     let instance = Self {
       state,

--- a/respo/src/ui/dialog/prompt.rs
+++ b/respo/src/ui/dialog/prompt.rs
@@ -86,7 +86,7 @@ where
   T: Clone + Debug + RespoAction,
 {
   let cursor = states.path();
-  let mut state = states.cast_branch::<InputState>()?;
+  let mut state = states.cast_branch::<InputState>();
   if let Some(text) = &options.initial_value {
     state = Rc::new(InputState {
       draft: text.to_string(),
@@ -365,7 +365,7 @@ where
 
   fn new(states: RespoStatesTree, options: PromptOptions, on_submit: U) -> Result<Self, String> {
     let cursor = states.path();
-    let state = states.cast_branch::<PromptPluginState>()?;
+    let state = states.cast_branch::<PromptPluginState>();
 
     let instance = Self {
       states,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified handling of state casting across multiple components by removing the `?` operator. This change improves code readability and maintainability.
  
- **Version Update**
  - Updated virtual DOM library version from 0.1.8 to 0.1.9 for better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->